### PR TITLE
Migrate OpenSymphony classes as indicated in the guide

### DIFF
--- a/src/main/resources/META-INF/rewrite/struts6.yml
+++ b/src/main/resources/META-INF/rewrite/struts6.yml
@@ -25,6 +25,7 @@ displayName: Migrate to Struts 6.0
 description: Migrate Struts 2.x to Struts 6.0
 recipeList:
   - org.openrewrite.java.struts.migrate6.MigrateAwareInterfaces
+  - org.openrewrite.java.struts.migrate6.MigrateOpenSymphonyClasses
   - org.openrewrite.java.struts.migrate6.UpgradeStruts6Dependencies
   - org.openrewrite.java.struts.MigrateStrutsDtd:
       strutsVersion: 6.0
@@ -198,3 +199,18 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.struts2.util.ServletContextAware
       newFullyQualifiedTypeName: org.apache.struts2.action.ServletContextAware
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.struts.migrate6.MigrateOpenSymphonyClasses
+displayName: Migrate OpenSymphony classes to Struts 6.0
+description: Migrate classes from `com.opensymphony.xwork2` to their replacements in `org.apache.struts2`.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.opensymphony.xwork2.config.providers.XmlConfigurationProvider
+      newFullyQualifiedTypeName: org.apache.struts2.config.StrutsXmlConfigurationProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.opensymphony.xwork2.conversion.TypeConversionException
+      newFullyQualifiedTypeName: org.apache.struts2.conversion.TypeConversionException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.opensymphony.xwork2.XWorkException
+      newFullyQualifiedTypeName: org.apache.struts2.StrutsException


### PR DESCRIPTION
- For https://github.com/openrewrite/rewrite-struts/issues/1

Mostly to flush out an issue at Sonatype with our snapshot patch versions, by releasing a new minor version.