### PR TITLE
Apply MSAL license when generating POMs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
+    id("org.openrewrite.build.moderne-source-available-license") version "latest.release"
 }
 
 group = "org.openrewrite.recipe"


### PR DESCRIPTION
The license should be included in POMs being published to Maven Central