### PR TITLE
Add `MigrateStruts6Constants` to the `MigrateStruts6` umbrella recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/struts6.yml
+++ b/src/main/resources/META-INF/rewrite/struts6.yml
@@ -28,6 +28,7 @@ recipeList:
   - org.openrewrite.java.struts.migrate6.MigrateAwareInterfaces
   - org.openrewrite.java.struts.migrate6.MigrateOpenSymphonyClasses
   - org.openrewrite.java.struts.migrate6.UpgradeStruts6Dependencies
+  - org.openrewrite.java.struts.migrate6.MigrateStruts6Constants
   - org.openrewrite.java.struts.MigrateStrutsDtd:
       strutsVersion: 6.0
 ---


### PR DESCRIPTION
## What's changed?
When running `org.openrewrite.java.struts.migrate6.MigrateStruts6` it should also run the `org.openrewrite.java.struts.migrate6.MigrateStruts6Constants` recipe.
