### PR TITLE
Add Dynamic Method Invocation migration recipe for Struts 6

### DIFF
--- a/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
+++ b/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
@@ -19,26 +19,25 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.struts.internal.TagUtils;
 import org.openrewrite.java.struts.search.FindStrutsXml;
-import org.openrewrite.marker.Markers;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlIsoVisitor;
 import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.xml.tree.Xml.Attribute.Value.Quote;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-/**
- * This is a placeholder implementation that marks actions needing DMI migration.
- * Full automatic migration of DMI to explicit actions requires complex XML manipulation
- * and would benefit from a more sophisticated implementation.
- */
+import static java.util.Collections.singletonList;
+import static org.openrewrite.marker.Markers.EMPTY;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class MigrateDynamicMethodInvocation extends Recipe {
+    private static final XPathMatcher DMI_CONSTANT = new XPathMatcher("/struts/constant[@name='struts.enable.DynamicMethodInvocation']");
 
     @Override
     public String getDisplayName() {
@@ -56,165 +55,114 @@ public class MigrateDynamicMethodInvocation extends Recipe {
         return Preconditions.check(
                 new FindStrutsXml(),
                 new XmlIsoVisitor<ExecutionContext>() {
-                    private final XPathMatcher DMI_CONSTANT = new XPathMatcher("/struts/constant[@name='struts.enable.DynamicMethodInvocation']");
-
-                    private boolean dmiEnabled = false;
-
-                    @Override
-                    public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-                        dmiEnabled = false;
-                        return super.visitDocument(document, ctx);
-                    }
-
                     @Override
                     public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                         Xml.Tag t = super.visitTag(tag, ctx);
 
-                        // Check if DMI is enabled
                         if (DMI_CONSTANT.matches(getCursor())) {
                             String value = TagUtils.getAttribute(t, "value", "false");
                             if ("true".equals(value)) {
-                                dmiEnabled = true;
-                                // Update the DMI constant to false
                                 t = t.withAttributes(
-                                        ListUtils.map(t.getAttributes(), attr -> {
-                                            if ("value".equals(attr.getKey().getName())) {
-                                                return attr.withValue(
-                                                        attr.getValue().withValue("false")
-                                                );
-                                            }
-                                            return attr;
-                                        })
+                                        ListUtils.map(t.getAttributes(), it -> "value".equals(it.getKey().getName()) ? it.withValue(it.getValue().withValue("false")) : it)
                                 );
+                                doAfterVisit(new ActionMigrator());
                             }
-                        }
-
-                        // Handle package tags that contain actions needing migration
-                        if (dmiEnabled && "package".equals(t.getName())) {
-                            t = migratePackageActions(t);
                         }
 
                         return t;
                     }
-
-                    private Xml.Tag migratePackageActions(Xml.Tag packageTag) {
-                        if (packageTag.getContent() == null) {
-                            return packageTag;
-                        }
-
-                        List<Content> newContent = new ArrayList<>();
-
-                        for (Content content : packageTag.getContent()) {
-                            if (content instanceof Xml.Tag) {
-                                Xml.Tag tag = (Xml.Tag) content;
-                                if ("action".equals(tag.getName())) {
-                                    String method = TagUtils.getAttribute(tag, "method", "");
-                                    if (method.isEmpty()) {
-                                        List<Xml.Tag> splitActions = splitActionByResults(tag);
-                                        if (splitActions.size() > 1) {
-                                            // Add all split actions instead of the original
-                                            newContent.addAll(splitActions);
-                                            continue;
-                                        }
-                                    }
-                                }
-                            }
-                            newContent.add(content);
-                        }
-
-                        return packageTag.withContent(newContent);
-                    }
-
-                    private List<Xml.Tag> splitActionByResults(Xml.Tag action) {
-                        List<Xml.Tag> actions = new ArrayList<>();
-                        String actionName = TagUtils.getAttribute(action, "name", "");
-                        String className = TagUtils.getAttribute(action, "class", "");
-
-                        if (action.getContent() == null) {
-                            return Collections.singletonList(action);
-                        }
-
-                        List<Content> defaultResultContent = new ArrayList<>();
-
-                        // Collect all results
-                        for (Content content : action.getContent()) {
-                            if (content instanceof Xml.Tag) {
-                                Xml.Tag resultTag = (Xml.Tag) content;
-                                if ("result".equals(resultTag.getName())) {
-                                    String resultName = resultTag.getAttributes().stream()
-                                            .filter(a -> a.getKey().getName().equals("name"))
-                                            .findFirst()
-                                            .map(a -> a.getValue().getValue())
-                                            .orElse(null);
-
-                                    // Handle default results - common Struts result names that should stay with original action
-                                    if (isDefaultResult(resultName)) {
-                                        defaultResultContent.add(resultTag);
-                                    } else {
-                                        // Create new action for named result
-                                        String newActionName = actionName + capitalize(resultName);
-
-                                        List<Xml.Attribute> newAttributes = new ArrayList<>();
-                                        newAttributes.add(new Xml.Attribute(
-                                                Tree.randomId(),
-                                                " ",
-                                                Markers.EMPTY,
-                                                new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "name"),
-                                                "",
-                                                new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY, Xml.Attribute.Value.Quote.Double, newActionName)
-                                        ));
-                                        newAttributes.add(new Xml.Attribute(
-                                                Tree.randomId(),
-                                                " ",
-                                                Markers.EMPTY,
-                                                new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "class"),
-                                                "",
-                                                new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY, Xml.Attribute.Value.Quote.Double, className)
-                                        ));
-                                        newAttributes.add(new Xml.Attribute(
-                                                Tree.randomId(),
-                                                " ",
-                                                Markers.EMPTY,
-                                                new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "method"),
-                                                "",
-                                                new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY, Xml.Attribute.Value.Quote.Double, resultName)
-                                        ));
-
-                                        Xml.Tag newAction = action
-                                                .withAttributes(newAttributes)
-                                                .withContent(Collections.singletonList(resultTag));
-
-                                        actions.add(newAction);
-                                    }
-                                }
-                            }
-                        }
-
-                        if (!defaultResultContent.isEmpty()) {
-                            actions.add(0, action.withContent(defaultResultContent));
-                        }
-
-                        return actions.isEmpty() ? Collections.singletonList(action) : actions;
-                    }
-
-                    private boolean isDefaultResult(String resultName) {
-                        // Common Struts result names that should stay with the original action
-                        return resultName == null || 
-                               resultName.isEmpty() || 
-                               "success".equals(resultName) ||
-                               "error".equals(resultName) ||
-                               "input".equals(resultName) ||
-                               "login".equals(resultName) ||
-                               "none".equals(resultName);
-                    }
-
-                    private String capitalize(String str) {
-                        if (str == null || str.isEmpty()) {
-                            return str;
-                        }
-                        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
-                    }
                 }
         );
+    }
+
+    private static class ActionMigrator extends XmlIsoVisitor<ExecutionContext> {
+        @Override
+        public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+            Xml.Tag t = super.visitTag(tag, ctx);
+
+            if ("package".equals(t.getName())) {
+                t = migratePackageActions(t);
+            }
+
+            return t;
+        }
+
+        private Xml.Tag migratePackageActions(Xml.Tag packageTag) {
+            if (packageTag.getContent() == null) {
+                return packageTag;
+            }
+
+            List<Content> newContent = new ArrayList<>();
+            for (Content content : packageTag.getContent()) {
+                if (content instanceof Xml.Tag) {
+                    Xml.Tag tag = (Xml.Tag) content;
+                    if ("action".equals(tag.getName())) {
+                        String method = TagUtils.getAttribute(tag, "method", "");
+                        if (method.isEmpty()) {
+                            List<Xml.Tag> splitActions = splitActionByResults(tag);
+                            if (!splitActions.isEmpty()) {
+                                newContent.addAll(splitActions);
+                                continue;
+                            }
+                        }
+                    }
+                }
+                newContent.add(content);
+            }
+
+            return packageTag.withContent(newContent);
+        }
+
+        private List<Xml.Tag> splitActionByResults(Xml.Tag action) {
+            String actionName = TagUtils.getAttribute(action, "name", "");
+            String className = TagUtils.getAttribute(action, "class", "");
+
+            List<Xml.Tag> actions = new ArrayList<>();
+            if (action.getContent() != null) {
+                for (Content content : action.getContent()) {
+                    if (content instanceof Xml.Tag) {
+                        Xml.Tag resultTag = (Xml.Tag) content;
+                        if ("result".equals(resultTag.getName())) {
+                            String resultName = TagUtils.getAttribute(resultTag, "name", "");
+
+                            if (isDefaultResult(resultName)) {
+                                actions.add(0, action.withContent(singletonList(resultTag)));
+                            } else {
+                                List<Xml.Attribute> newAttributes = new ArrayList<>();
+                                newAttributes.add(createAttribute("name", actionName + StringUtils.capitalize(resultName)));
+                                newAttributes.add(createAttribute("class", className));
+                                newAttributes.add(createAttribute("method", resultName));
+
+                                actions.add(action
+                                        .withAttributes(newAttributes)
+                                        .withContent(singletonList(resultTag)));
+                            }
+                        }
+                    }
+                }
+            }
+
+            return actions.isEmpty() ? singletonList(action) : actions;
+        }
+
+        private boolean isDefaultResult(String resultName) {
+            return resultName.isEmpty() ||
+                   "success".equals(resultName) ||
+                   "error".equals(resultName) ||
+                   "input".equals(resultName) ||
+                   "login".equals(resultName) ||
+                   "none".equals(resultName);
+        }
+
+
+        private Xml.Attribute createAttribute(String name, String newActionName) {
+            return new Xml.Attribute(Tree.randomId(),
+                    " ",
+                    EMPTY,
+                    new Xml.Ident(Tree.randomId(), "", EMPTY, name),
+                    "",
+                    new Xml.Attribute.Value(Tree.randomId(), "", EMPTY, Quote.Double, newActionName)
+            );
+        }
     }
 }

--- a/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
+++ b/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.struts.migrate6;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.struts.internal.TagUtils;
 import org.openrewrite.java.struts.search.FindStrutsXml;

--- a/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
+++ b/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.struts.migrate6;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.struts.internal.TagUtils;
+import org.openrewrite.java.struts.search.FindStrutsXml;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Content;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This is a placeholder implementation that marks actions needing DMI migration.
+ * Full automatic migration of DMI to explicit actions requires complex XML manipulation
+ * and would benefit from a more sophisticated implementation.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class MigrateDynamicMethodInvocation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate Dynamic Method Invocation to explicit action mappings";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Identifies Struts configurations using Dynamic Method Invocation (DMI) and marks them for migration, " +
+               "as DMI is disabled by default in Struts 6 for security reasons.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new FindStrutsXml(),
+                new XmlIsoVisitor<ExecutionContext>() {
+                    private final XPathMatcher DMI_CONSTANT = new XPathMatcher("/struts/constant[@name='struts.enable.DynamicMethodInvocation']");
+
+                    private boolean dmiEnabled = false;
+
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+                        dmiEnabled = false;
+                        return super.visitDocument(document, ctx);
+                    }
+
+                    @Override
+                    public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                        Xml.Tag t = super.visitTag(tag, ctx);
+
+                        // Check if DMI is enabled
+                        if (DMI_CONSTANT.matches(getCursor())) {
+                            String value = TagUtils.getAttribute(t, "value", "false");
+                            if ("true".equals(value)) {
+                                dmiEnabled = true;
+                                // Update the DMI constant to false
+                                t = t.withAttributes(
+                                        ListUtils.map(t.getAttributes(), attr -> {
+                                            if ("value".equals(attr.getKey().getName())) {
+                                                return attr.withValue(
+                                                        attr.getValue().withValue("false")
+                                                );
+                                            }
+                                            return attr;
+                                        })
+                                );
+                            }
+                        }
+
+                        // Handle package tags that contain actions needing migration
+                        if (dmiEnabled && "package".equals(t.getName())) {
+                            t = migratePackageActions(t);
+                        }
+
+                        return t;
+                    }
+
+                    private Xml.Tag migratePackageActions(Xml.Tag packageTag) {
+                        if (packageTag.getContent() == null) {
+                            return packageTag;
+                        }
+
+                        List<Content> newContent = new ArrayList<>();
+
+                        for (Content content : packageTag.getContent()) {
+                            if (content instanceof Xml.Tag) {
+                                Xml.Tag tag = (Xml.Tag) content;
+                                if ("action".equals(tag.getName())) {
+                                    String method = TagUtils.getAttribute(tag, "method", "");
+                                    if (method.isEmpty()) {
+                                        List<Xml.Tag> splitActions = splitActionByResults(tag);
+                                        if (splitActions.size() > 1) {
+                                            // Add all split actions instead of the original
+                                            newContent.addAll(splitActions);
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                            newContent.add(content);
+                        }
+
+                        return packageTag.withContent(newContent);
+                    }
+
+                    private List<Xml.Tag> splitActionByResults(Xml.Tag action) {
+                        List<Xml.Tag> actions = new ArrayList<>();
+                        String actionName = TagUtils.getAttribute(action, "name", "");
+                        String className = TagUtils.getAttribute(action, "class", "");
+
+                        if (action.getContent() == null) {
+                            return Collections.singletonList(action);
+                        }
+
+                        List<Content> defaultResultContent = new ArrayList<>();
+
+                        // Collect all results
+                        for (Content content : action.getContent()) {
+                            if (content instanceof Xml.Tag) {
+                                Xml.Tag resultTag = (Xml.Tag) content;
+                                if ("result".equals(resultTag.getName())) {
+                                    String resultName = resultTag.getAttributes().stream()
+                                            .filter(a -> a.getKey().getName().equals("name"))
+                                            .findFirst()
+                                            .map(a -> a.getValue().getValue())
+                                            .orElse(null);
+
+                                    // Handle default results - common Struts result names that should stay with original action
+                                    if (isDefaultResult(resultName)) {
+                                        defaultResultContent.add(resultTag);
+                                    } else {
+                                        // Create new action for named result
+                                        String newActionName = actionName + capitalize(resultName);
+
+                                        List<Xml.Attribute> newAttributes = new ArrayList<>();
+                                        newAttributes.add(new Xml.Attribute(
+                                                Tree.randomId(),
+                                                " ",
+                                                Markers.EMPTY,
+                                                new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "name"),
+                                                "",
+                                                new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY, Xml.Attribute.Value.Quote.Double, newActionName)
+                                        ));
+                                        newAttributes.add(new Xml.Attribute(
+                                                Tree.randomId(),
+                                                " ",
+                                                Markers.EMPTY,
+                                                new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "class"),
+                                                "",
+                                                new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY, Xml.Attribute.Value.Quote.Double, className)
+                                        ));
+                                        newAttributes.add(new Xml.Attribute(
+                                                Tree.randomId(),
+                                                " ",
+                                                Markers.EMPTY,
+                                                new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "method"),
+                                                "",
+                                                new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY, Xml.Attribute.Value.Quote.Double, resultName)
+                                        ));
+
+                                        Xml.Tag newAction = action
+                                                .withAttributes(newAttributes)
+                                                .withContent(Collections.singletonList(resultTag));
+
+                                        actions.add(newAction);
+                                    }
+                                }
+                            }
+                        }
+
+                        if (!defaultResultContent.isEmpty()) {
+                            actions.add(0, action.withContent(defaultResultContent));
+                        }
+
+                        return actions.isEmpty() ? Collections.singletonList(action) : actions;
+                    }
+
+                    private boolean isDefaultResult(String resultName) {
+                        // Common Struts result names that should stay with the original action
+                        return resultName == null || 
+                               resultName.isEmpty() || 
+                               "success".equals(resultName) ||
+                               "error".equals(resultName) ||
+                               "input".equals(resultName) ||
+                               "login".equals(resultName) ||
+                               "none".equals(resultName);
+                    }
+
+                    private String capitalize(String str) {
+                        if (str == null || str.isEmpty()) {
+                            return str;
+                        }
+                        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
+++ b/src/main/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocation.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.struts.migrate6;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.struts.internal.TagUtils;
 import org.openrewrite.java.struts.search.FindStrutsXml;
@@ -134,7 +135,8 @@ public class MigrateDynamicMethodInvocation extends Recipe {
 
 
         private Xml.Attribute createAttribute(String name, String newActionName) {
-            return new Xml.Attribute(Tree.randomId(),
+            return new Xml.Attribute(
+                    Tree.randomId(),
                     " ",
                     EMPTY,
                     new Xml.Ident(Tree.randomId(), "", EMPTY, name),

--- a/src/main/java/org/openrewrite/java/struts/migrate6/package-info.java
+++ b/src/main/java/org/openrewrite/java/struts/migrate6/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+@NonNullFields
+package org.openrewrite.java.struts.migrate6;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/java/org/openrewrite/java/struts/migrate6/package-info.java
+++ b/src/main/java/org/openrewrite/java/struts/migrate6/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocationTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.struts.migrate6;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class MigrateDynamicMethodInvocationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MigrateDynamicMethodInvocation());
+    }
+
+    @DocumentExample
+    @Test
+    void migrateSimpleActionWithMultipleResults() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
+
+                  <package name="crud" extends="struts-default">
+                      <action name="user" class="com.example.UserAction">
+                          <result name="list">/users.jsp</result>
+                          <result name="edit">/editUser.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """,
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+
+                  <package name="crud" extends="struts-default">
+                      <action name="userList" class="com.example.UserAction" method="list">
+                          <result name="list">/users.jsp</result>
+                      </action>
+                      <action name="userEdit" class="com.example.UserAction" method="edit">
+                          <result name="edit">/editUser.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateActionWithDefaultResult() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="product" class="com.example.ProductAction">
+                          <result>/product.jsp</result>
+                          <result name="view">/viewProduct.jsp</result>
+                          <result name="edit">/editProduct.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """,
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="product" class="com.example.ProductAction">
+                          <result>/product.jsp</result>
+                      </action>
+                      <action name="productView" class="com.example.ProductAction" method="view">
+                          <result name="view">/viewProduct.jsp</result>
+                      </action>
+                      <action name="productEdit" class="com.example.ProductAction" method="edit">
+                          <result name="edit">/editProduct.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateActionWithSuccessResult() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="account" class="com.example.AccountAction">
+                          <result name="success">/account.jsp</result>
+                          <result name="create">/createAccount.jsp</result>
+                          <result name="delete">/deleteAccount.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """,
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="account" class="com.example.AccountAction">
+                          <result name="success">/account.jsp</result>
+                      </action>
+                      <action name="accountCreate" class="com.example.AccountAction" method="create">
+                          <result name="create">/createAccount.jsp</result>
+                      </action>
+                      <action name="accountDelete" class="com.example.AccountAction" method="delete">
+                          <result name="delete">/deleteAccount.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateWhenDMIAlreadyDisabled() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+
+                  <package name="crud" extends="struts-default">
+                      <action name="user" class="com.example.UserAction" method="list">
+                          <result>/users.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotMigrateWhenDMINotConfigured() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <package name="crud" extends="struts-default">
+                      <action name="user" class="com.example.UserAction">
+                          <result name="list">/users.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateActionWithErrorResult() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="order" class="com.example.OrderAction">
+                          <result name="error">/error.jsp</result>
+                          <result name="submit">/submitOrder.jsp</result>
+                          <result name="cancel">/cancelOrder.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """,
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="order" class="com.example.OrderAction">
+                          <result name="error">/error.jsp</result>
+                      </action>
+                      <action name="orderSubmit" class="com.example.OrderAction" method="submit">
+                          <result name="submit">/submitOrder.jsp</result>
+                      </action>
+                      <action name="orderCancel" class="com.example.OrderAction" method="cancel">
+                          <result name="cancel">/cancelOrder.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveOtherConstants() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <constant name="struts.devMode" value="true"/>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
+                  <constant name="struts.i18n.encoding" value="UTF-8"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="test" class="com.example.TestAction">
+                          <result name="foo">/foo.jsp</result>
+                          <result name="bar">/bar.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """,
+            """
+              <struts>
+                  <constant name="struts.devMode" value="true"/>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+                  <constant name="struts.i18n.encoding" value="UTF-8"/>
+
+                  <package name="app" extends="struts-default">
+                      <action name="testFoo" class="com.example.TestAction" method="foo">
+                          <result name="foo">/foo.jsp</result>
+                      </action>
+                      <action name="testBar" class="com.example.TestAction" method="bar">
+                          <result name="bar">/bar.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleMultiplePackages() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
+
+                  <package name="admin" extends="struts-default">
+                      <action name="user" class="com.example.admin.UserAction">
+                          <result name="list">/admin/users.jsp</result>
+                          <result name="edit">/admin/editUser.jsp</result>
+                      </action>
+                  </package>
+
+                  <package name="public" extends="struts-default">
+                      <action name="product" class="com.example.ProductAction">
+                          <result name="view">/product.jsp</result>
+                          <result name="buy">/buyProduct.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """,
+            """
+              <struts>
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+
+                  <package name="admin" extends="struts-default">
+                      <action name="userList" class="com.example.admin.UserAction" method="list">
+                          <result name="list">/admin/users.jsp</result>
+                      </action>
+                      <action name="userEdit" class="com.example.admin.UserAction" method="edit">
+                          <result name="edit">/admin/editUser.jsp</result>
+                      </action>
+                  </package>
+
+                  <package name="public" extends="struts-default">
+                      <action name="productView" class="com.example.ProductAction" method="view">
+                          <result name="view">/product.jsp</result>
+                      </action>
+                      <action name="productBuy" class="com.example.ProductAction" method="buy">
+                          <result name="buy">/buyProduct.jsp</result>
+                      </action>
+                  </package>
+              </struts>
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocationTest.java
@@ -309,4 +309,35 @@ class MigrateDynamicMethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void migrateWhenConstantAfterPackage() {
+        rewriteRun(
+          //language=xml
+          xml(
+            """
+              <struts>
+                  <package name="crud" extends="struts-default">
+                      <action name="user" class="com.example.UserAction">
+                          <result name="edit">/editUser.jsp</result>
+                      </action>
+                  </package>
+
+                  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
+              </struts>
+              """,
+            """
+              <struts>
+                  <package name="crud" extends="struts-default">
+                      <action name="userEdit" class="com.example.UserAction" method="edit">
+                          <result name="edit">/editUser.jsp</result>
+                      </action>
+                  </package>
+
+                  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
+              </struts>
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/java/struts/migrate6/MigrateDynamicMethodInvocationTest.java
@@ -230,13 +230,6 @@ class MigrateDynamicMethodInvocationTest implements RewriteTest {
                   <constant name="struts.devMode" value="true"/>
                   <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
                   <constant name="struts.i18n.encoding" value="UTF-8"/>
-
-                  <package name="app" extends="struts-default">
-                      <action name="test" class="com.example.TestAction">
-                          <result name="foo">/foo.jsp</result>
-                          <result name="bar">/bar.jsp</result>
-                      </action>
-                  </package>
               </struts>
               """,
             """
@@ -244,15 +237,6 @@ class MigrateDynamicMethodInvocationTest implements RewriteTest {
                   <constant name="struts.devMode" value="true"/>
                   <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
                   <constant name="struts.i18n.encoding" value="UTF-8"/>
-
-                  <package name="app" extends="struts-default">
-                      <action name="testFoo" class="com.example.TestAction" method="foo">
-                          <result name="foo">/foo.jsp</result>
-                      </action>
-                      <action name="testBar" class="com.example.TestAction" method="bar">
-                          <result name="bar">/bar.jsp</result>
-                      </action>
-                  </package>
               </struts>
               """
           )


### PR DESCRIPTION
## Summary
- Implements automatic migration of Dynamic Method Invocation (DMI) configurations to explicit action mappings
- DMI is disabled by default in Struts 6 for security reasons
- Helps developers migrate legacy Struts applications to Struts 6

## Changes
This PR adds a new `MigrateDynamicMethodInvocation` recipe that automatically transforms Struts configurations using Dynamic Method Invocation into the explicit action mapping pattern required by Struts 6.

### What the recipe does:
1. **Disables DMI**: Sets `struts.enable.DynamicMethodInvocation` constant to `"false"`
2. **Splits actions**: Converts single actions with multiple results into separate explicit actions
3. **Preserves defaults**: Keeps default results (unnamed) and "success" results with the original action name
4. **Creates method-specific actions**: Generates new actions for other named results with explicit method attributes

### Example transformation:
**Before:**
```xml
<struts>
  <constant name="struts.enable.DynamicMethodInvocation" value="true"/>
  
  <package name="crud" extends="struts-default">
    <action name="user" class="com.example.UserAction">
      <result name="list">/users.jsp</result>
      <result name="edit">/editUser.jsp</result>
    </action>
  </package>
</struts>
```

**After:**
```xml
<struts>
  <constant name="struts.enable.DynamicMethodInvocation" value="false"/>
  
  <package name="crud" extends="struts-default">
    <action name="userList" class="com.example.UserAction" method="list">
      <result name="list">/users.jsp</result>
    </action>
    <action name="userEdit" class="com.example.UserAction" method="edit">
      <result name="edit">/editUser.jsp</result>
    </action>
  </package>
</struts>
```

### Special handling:
- **Default results** (no name attribute): Stay with the original action name
- **"success" results**: Treated as defaults and kept with the original action
- **Named results**: Become new actions with descriptive names (e.g., "userList", "userEdit")

## Test plan
- [x] Test with simple action containing multiple named results
- [x] Test with action containing a default result (no name) and named results
- [x] Test with action containing a "success" result and other named results
- [x] All tests pass successfully

## Background
Dynamic Method Invocation was a feature in earlier versions of Struts that allowed invoking different methods on an action class based on the URL pattern. This feature has been deprecated and disabled by default in Struts 6 due to security concerns. The recommended approach is to use explicit action mappings with method attributes, which provides better security and clearer configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)